### PR TITLE
empty results breaks cloudwatch put_metric_data

### DIFF
--- a/lib/puma_cloudwatch/metrics/looper.rb
+++ b/lib/puma_cloudwatch/metrics/looper.rb
@@ -34,7 +34,7 @@ class PumaCloudwatch::Metrics
       loop do
         stats = Fetcher.new(@options).call
         results = Parser.new(stats).call
-        Sender.new(results).call
+        Sender.new(results).call unless results.empty?
         sleep @frequency
       end
     end


### PR DESCRIPTION
After boot, my first results read is empty, causing the looper to break while calling put_metric_data on cloudwatch client with the following error:
`The parameter MetricData is required. (Aws::CloudWatch::Errors::MissingParameter)`