### PR TITLE
Eliminate the need to add Array#sum

### DIFF
--- a/lib/puma_cloudwatch/core_ext.rb
+++ b/lib/puma_cloudwatch/core_ext.rb
@@ -2,6 +2,5 @@
 major, minor, _ = RUBY_VERSION.split('.')
 if major == '2' && minor == '3'
   require "puma_cloudwatch/core_ext/thread"
-  require "puma_cloudwatch/core_ext/array"
   require "pp"
 end

--- a/lib/puma_cloudwatch/core_ext/array.rb
+++ b/lib/puma_cloudwatch/core_ext/array.rb
@@ -1,7 +1,0 @@
-class Array
-  # Note: Array#sum only available in ruby 2.4+
-  # Thanks: http://www.viarails.net/q/How-to-sum-an-array-of-numbers-in-Ruby
-  def sum
-    inject(0) {|sum, i|  sum + i }
-  end
-end

--- a/lib/puma_cloudwatch/metrics/sender.rb
+++ b/lib/puma_cloudwatch/metrics/sender.rb
@@ -57,7 +57,7 @@ class PumaCloudwatch::Metrics
             dimensions: dimensions,
             statistic_values: {
               sample_count: values.length,
-              sum: values.sum,
+              sum: values.inject(0) { |sum, el| sum += el },
               minimum: values.min,
               maximum: values.max
             }


### PR DESCRIPTION
The added `#sum` method collides with, and could break, projects on Ruby versions >= 2.4, and projects that use the `activesupport` gem.

It's only used in one place in the `puma-cloudwatch` gem–it's safest to rewrite that one place to not need `Array#sum`.