### PR TITLE
Enabling high-resolution Cloudwatch metrics if frequency is lower tha…

### DIFF
--- a/lib/puma_cloudwatch/metrics/sender.rb
+++ b/lib/puma_cloudwatch/metrics/sender.rb
@@ -16,6 +16,7 @@ class PumaCloudwatch::Metrics
       @namespace = ENV['PUMA_CLOUDWATCH_NAMESPACE'] || "WebServer"
       @dimension_name = ENV['PUMA_CLOUDWATCH_DIMENSION_NAME'] || "App"
       @dimension_value = ENV['PUMA_CLOUDWATCH_DIMENSION_VALUE'] || "puma"
+      @frequency = Integer(ENV['PUMA_CLOUDWATCH_FREQUENCY'] || 60)
       @enabled = ENV['PUMA_CLOUDWATCH_ENABLED'] || false
     end
 
@@ -55,6 +56,7 @@ class PumaCloudwatch::Metrics
           data << {
             metric_name: name.to_s,
             dimensions: dimensions,
+            storage_resolution: @frequency < 60 ? 1 : 60,
             statistic_values: {
               sample_count: values.length,
               sum: values.inject(0) { |sum, el| sum += el },

--- a/lib/puma_cloudwatch/version.rb
+++ b/lib/puma_cloudwatch/version.rb
@@ -1,3 +1,3 @@
 module PumaCloudwatch
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end


### PR DESCRIPTION
This provides the storage_resolution option to the `put_metric_data` call so that if the frequency is less than 60s than high-resolution metrics are enabled: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics